### PR TITLE
Fix sanity post display bug

### DIFF
--- a/SECTION_FIXES.md
+++ b/SECTION_FIXES.md
@@ -1,0 +1,94 @@
+# إصلاحات صفحة الأقسام - Section Page Fixes
+
+## الأخطاء التي تم إصلاحها
+
+### 1. عدم وجود Sanity Client
+**المشكلة**: كان ملف `js/section-script.js` يحاول استخدام متغير `client` غير معرف
+**الحل**: تم إضافة استيراد وتكوين Sanity Client في بداية الملف
+
+```javascript
+import { createClient } from 'https://cdn.skypack.dev/@sanity/client';
+
+const client = createClient({
+  projectId: '00ycpx1i',
+  dataset: 'production',
+  apiVersion: '2023-01-01',
+  useCdn: false,
+});
+```
+
+### 2. عدم توافق أنواع البيانات
+**المشكلة**: كان هناك تضارب بين نوع `post` في صفحة الأقسام ونوع `article` في صفحة المقال
+**الحل**: تم توحيد النوع إلى `post` في كلا الملفين
+
+### 3. عدم دعم معاملات Slug
+**المشكلة**: كانت صفحة الأقسام تنشئ روابط بمعامل `slug` لكن صفحة المقال لا تدعم إلا معامل `id`
+**الحل**: تم تحديث `js/article-script.js` لدعم كلا المعاملين
+
+## كيفية الاستخدام
+
+### 1. صفحة الأقسام
+```
+pages/section.html?categoryId=CATEGORY_ID
+```
+
+### 2. صفحة المقال
+يمكن الوصول إليها بطريقتين:
+```
+pages/article.html?id=POST_ID
+pages/article.html?slug=POST_SLUG
+```
+
+### 3. صفحة الاختبار
+تم إنشاء صفحة اختبار في `pages/test-section.html` لاختبار الوظائف
+
+## البنية المتوقعة في Sanity
+
+### نوع Category
+```javascript
+{
+  _type: "category",
+  _id: "category-id",
+  title: "عنوان القسم",
+  description: "وصف القسم"
+}
+```
+
+### نوع Post
+```javascript
+{
+  _type: "post",
+  _id: "post-id",
+  title: "عنوان المقال",
+  slug: { current: "post-slug" },
+  description: "وصف المقال",
+  content: [], // Portable Text أو نص
+  mainImage: {
+    asset: { url: "image-url" }
+  },
+  publishedAt: "2024-01-01",
+  author: { name: "اسم الكاتب" },
+  category: { _ref: "category-id" }
+}
+```
+
+## الملفات المحدثة
+
+1. `js/section-script.js` - إضافة Sanity Client
+2. `js/article-script.js` - دعم slug ومعالجة نوع post
+3. `pages/test-section.html` - صفحة اختبار جديدة
+
+## كيفية الاختبار
+
+1. افتح `pages/test-section.html` في المتصفح
+2. انقر على الروابط التجريبية
+3. تحقق من وحدة التحكم للأخطاء
+4. تأكد من عرض المقالات بشكل صحيح
+
+## التحسينات المضافة
+
+- معالجة أفضل للأخطاء
+- دعم كامل لـ Portable Text
+- عرض معلومات الكاتب وتاريخ النشر
+- تصميم متجاوب للأجهزة المحمولة
+- روابط تنقل محسنة

--- a/js/section-script.js
+++ b/js/section-script.js
@@ -1,3 +1,12 @@
+import { createClient } from 'https://cdn.skypack.dev/@sanity/client';
+
+const client = createClient({
+  projectId: '00ycpx1i',
+  dataset: 'production',
+  apiVersion: '2023-01-01',
+  useCdn: false, // الأفضل تخليه false أثناء التطوير لتفادي الكاش
+});
+
 // Section Page JavaScript Functionality
 class SectionPage {
     constructor() {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes section and article pages to correctly display Sanity posts by adding the Sanity client, unifying data types, and enabling slug-based navigation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `section-script.js` file was missing the Sanity client configuration, and there was an inconsistency in data types (`post` vs `article`) between the section and article queries. Additionally, the article page did not support navigation via `slug` parameters, which the section page was generating. This PR resolves these issues to ensure seamless display and navigation of Sanity posts.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ec82e80-238c-47b5-94a6-0f90ee69902e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ec82e80-238c-47b5-94a6-0f90ee69902e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>