### PR TITLE
Fix bugs and post display error

### DIFF
--- a/js/topic-script.js
+++ b/js/topic-script.js
@@ -63,7 +63,7 @@ class TopicPage {
         
         // Update breadcrumb
         document.getElementById('sectionLink').textContent = this.currentSection.title;
-        document.getElementById('sectionLink').href = `section.html?sectionId=${this.currentSection.id}`;
+        document.getElementById('sectionLink').href = `section.html?categoryId=${this.currentSection.id}`;
         document.getElementById('topicTitle').textContent = this.currentTopic.title;
         
         // Update topic header

--- a/pages/debug.html
+++ b/pages/debug.html
@@ -166,7 +166,7 @@
                         window.location.href = '../home.html';
                         break;
                     case 'section':
-                        window.location.href = 'section.html?sectionId=aqeedah';
+                        window.location.href = 'section.html?categoryId=aqeedah';
                         break;
                     case 'topic':
                         window.location.href = 'topic.html?sectionId=aqeedah&topicId=tawheed';


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update section page links to use `categoryId` instead of `sectionId` to correctly display posts.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `section.html` page's script expects `categoryId` to fetch and display posts. Previously, links from `topic-script.js` and the debug page were passing `sectionId`, causing the page to fail to load content and instead show an error or redirect. This change aligns the parameter name with the expected one, resolving the display issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-56f3edf1-79a8-491a-8e27-baa07ec5b804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56f3edf1-79a8-491a-8e27-baa07ec5b804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>